### PR TITLE
Fix BottleItem only giving one glass bottle regardless of stack size (Fabric 1.21.1)

### DIFF
--- a/Fabric/src/main/java/com/skniro/usefulfood/item/init/ItemBottle.java
+++ b/Fabric/src/main/java/com/skniro/usefulfood/item/init/ItemBottle.java
@@ -4,14 +4,11 @@ import com.skniro.usefulfood.item.UsefulFoodItems;
 import net.minecraft.advancement.criterion.Criteria;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemUsage;
-import net.minecraft.item.Items;
+import net.minecraft.item.*;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.stat.Stats;
-import net.minecraft.util.Hand;
-import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.UseAction;
 import net.minecraft.world.World;
 
@@ -23,18 +20,38 @@ public class ItemBottle
         super(settings);
     }
 
-
     public ItemStack finishUsing(ItemStack stack, World world, LivingEntity user) {
-        if (!world.isClient && stack.isOf(UsefulFoodItems.MilkBottle)) {
-            user.clearStatusEffects();
+        PlayerEntity playerEntity;
+        super.finishUsing(stack, world, user);
+
+        // Advancement check + stat
+        if (user instanceof ServerPlayerEntity serverPlayerEntity) {
+            Criteria.CONSUME_ITEM.trigger(serverPlayerEntity, stack);
+            serverPlayerEntity.incrementStat(Stats.USED.getOrCreateStat(this));
         }
-        ItemStack itemStack = super.finishUsing(stack, world, user);
-        return user instanceof PlayerEntity && ((PlayerEntity)user).getAbilities().creativeMode ? itemStack : new ItemStack(Items.GLASS_BOTTLE);
+
+        // Clear statuses (if milk)
+        if (!world.isClient && stack.isOf(UsefulFoodItems.MilkBottle))
+            user.clearStatusEffects();
+
+
+        if (user instanceof PlayerEntity && !(playerEntity = (PlayerEntity)user).isInCreativeMode()) {
+            ItemStack itemStack = new ItemStack(Items.GLASS_BOTTLE);
+            if (!playerEntity.getInventory().insertStack(itemStack)) {
+                playerEntity.dropItem(itemStack, false);
+            }
+        }
+        return stack;
     }
 
     @Override
     public int getMaxUseTime(ItemStack stack, LivingEntity user) {
         return MAX_USE_TIME;
+    }
+
+    @Override
+    public SoundEvent getEatSound() {
+        return SoundEvents.ENTITY_GENERIC_DRINK;
     }
 
     @Override


### PR DESCRIPTION
If you were to alter the stack size of any BottleItem, it would void the rest of the stack upon consumption. This commit fixes this by having BottleItem function more similar to HoneyBottleItem, whilst retaining BottleItem's unique functionality. As a side effect, it also exposes consumption of BottleItem to an advancement trigger and statistics